### PR TITLE
feat: `no_std` support

### DIFF
--- a/kinded/Cargo.toml
+++ b/kinded/Cargo.toml
@@ -15,5 +15,9 @@ categories = ["data-structures", "rust-patterns"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = []
+no_std = []
+
 [dependencies]
 kinded_macros = { version = "0.3.0", path = "../kinded_macros" }

--- a/kinded/src/errors.rs
+++ b/kinded/src/errors.rs
@@ -1,3 +1,8 @@
+extern crate alloc;
+
+#[cfg(feature = "no_std")]
+use alloc::string::{String, ToString};
+
 /// An error which is returned when parsing of a kind type failures.
 pub struct ParseKindError {
     kind_type_name: String,
@@ -8,7 +13,7 @@ impl ParseKindError {
     /// This method is used by `kinded` macro to construct an error for FromStr trait and is not
     /// recommend for a direct usage by users.
     pub fn from_type_and_string<KindType>(given_string: String) -> ParseKindError {
-        let full_kind_type_name = std::any::type_name::<KindType>();
+        let full_kind_type_name = core::any::type_name::<KindType>();
         let kind_type_name = full_kind_type_name
             .split("::")
             .last()
@@ -37,6 +42,7 @@ impl ::core::fmt::Debug for ParseKindError {
     }
 }
 
+#[cfg(not(feature = "no_std"))]
 impl ::std::error::Error for ParseKindError {
     fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
         None

--- a/kinded/src/lib.rs
+++ b/kinded/src/lib.rs
@@ -187,6 +187,8 @@
 //!
 //! MIT © [Serhii Potapov](https://www.greyblake.com)
 
+#![cfg_attr(feature = "no_std", no_std)]
+
 mod errors;
 mod traits;
 

--- a/kinded_macros/src/gen/kind_enum.rs
+++ b/kinded_macros/src/gen/kind_enum.rs
@@ -74,8 +74,8 @@ fn gen_impl_display_trait(meta: &Meta) -> TokenStream {
     });
 
     quote!(
-        impl std::fmt::Display for #kind_name {                                     // impl std::fmt::Display for DrinkKind {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {    //     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        impl core::fmt::Display for #kind_name {                                    // impl core::fmt::Display for DrinkKind {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {  //     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 match self {                                                        //         match self {
                     #(#match_branches),*                                            //             DrinkKind::Mate => write!(f, "mate"),
                 }                                                                   //         }

--- a/kinded_macros/src/gen/kind_enum.rs
+++ b/kinded_macros/src/gen/kind_enum.rs
@@ -127,6 +127,7 @@ fn gen_impl_from_str_trait(meta: &Meta) -> TokenStream {
                 }                                                              // }
 
                 // If still no success, then return an error
+                use alloc::borrow::ToOwned;
                 let error = ::kinded::ParseKindError::from_type_and_string::<#kind_name>(s.to_owned());
                 Err(error)
             }


### PR DESCRIPTION
I implemented a feature flag `no_std` which enables `no_std` support (duh). I also changed some APIs from `std` to `core`.

Closes #13 