### PR TITLE
Feat: ability to add inner attributes to generated kind enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
 name = "kinded"
 version = "0.3.0"
 dependencies = [
@@ -30,21 +36,27 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.32"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "sandbox"
@@ -54,10 +66,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "2.0.28"
+name = "serde"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.197"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -69,6 +112,8 @@ name = "test_suite"
 version = "0.1.0"
 dependencies = [
  "kinded",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/kinded/src/lib.rs
+++ b/kinded/src/lib.rs
@@ -121,6 +121,27 @@
 //! drink_kinds.insert(DrinkKind::Mate);
 //! ```
 //!
+//! ### Generic attributes
+//!
+//! If you're using derive traits from other libraries like Serde or Sqlx, you might want to add
+//! extra attributes specific to those libraries. You can add these by using the `attrs` attribute:
+//!
+//! ```no_run
+//! use kinded::Kinded;
+//! use serde::Serialize;
+//! use serde_json::json;
+//!
+//! #[derive(Kinded, Serialize)]
+//! #[kinded(display = "snake_case", attrs(serde(rename_all = "snake_case")))]
+//! enum Drink {
+//!     VeryHotBlackTea,
+//!     Milk { fat: f64 },
+//! }
+//!
+//! let json_value = serde_json::to_value(&DrinkKind::VeryHotBlackTea);
+//! assert_eq!(json_value, json!("very_hot_black_tea"));
+//! ```
+//!
 //! ### Customize Display trait
 //!
 //! Implementation of `Display` trait can be customized in the `serde` fashion:

--- a/kinded/src/lib.rs
+++ b/kinded/src/lib.rs
@@ -126,7 +126,7 @@
 //! If you're using derive traits from other libraries like Serde or Sqlx, you might want to add
 //! extra attributes specific to those libraries. You can add these by using the `attrs` attribute:
 //!
-//! ```no_run
+//! ```ignore
 //! use kinded::Kinded;
 //! use serde::Serialize;
 //! use serde_json::json;

--- a/kinded_macros/src/gen/kind_enum.rs
+++ b/kinded_macros/src/gen/kind_enum.rs
@@ -23,11 +23,11 @@ fn gen_definition(meta: &Meta) -> TokenStream {
     let kind_name = meta.kind_name();
     let variant_names: Vec<&Ident> = meta.variants.iter().map(|v| &v.ident).collect();
     let traits = meta.derive_traits();
-    let attrs = meta.derive_attrs();
+    let attrs = meta.meta_attrs();
 
     quote!(
         #[derive(#(#traits),*)]                                                // #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-        #(#[#attrs]),*
+        #(#[#attrs]),*                                                         // #[serde(rename_all = "camelCase")]
         #vis enum #kind_name {                                                 // pub enum DrinkKind {
             #(#variant_names),*                                                //     Mate, Coffee, Tea
         }                                                                      // }

--- a/kinded_macros/src/gen/kind_enum.rs
+++ b/kinded_macros/src/gen/kind_enum.rs
@@ -23,9 +23,11 @@ fn gen_definition(meta: &Meta) -> TokenStream {
     let kind_name = meta.kind_name();
     let variant_names: Vec<&Ident> = meta.variants.iter().map(|v| &v.ident).collect();
     let traits = meta.derive_traits();
+    let attrs = meta.derive_attrs();
 
     quote!(
         #[derive(#(#traits),*)]                                                // #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        #(#[#attrs]),*
         #vis enum #kind_name {                                                 // pub enum DrinkKind {
             #(#variant_names),*                                                //     Mate, Coffee, Tea
         }                                                                      // }

--- a/kinded_macros/src/models.rs
+++ b/kinded_macros/src/models.rs
@@ -56,10 +56,10 @@ impl Meta {
         quote!(#type_name #generics)
     }
 
-    pub fn derive_attrs(&self) -> Vec<SynMeta> {
-        self.kinded_attrs.attr
+    pub fn meta_attrs(&self) -> Vec<SynMeta> {
+        self.kinded_attrs.meta_attrs
             .clone()
-            .unwrap_or(Vec::new())
+            .unwrap_or_else(|| Vec::new())
     }
 }
 
@@ -94,7 +94,8 @@ pub struct KindedAttributes {
     /// Attributes to customize implementation for Display trait
     pub display: Option<DisplayCase>,
 
-    pub attr: Option<Vec<SynMeta>>,
+    /// Internal meta attributes for attributes like `#[serde(rename_all = "camelCase")]`.
+    pub meta_attrs: Option<Vec<SynMeta>>,
 }
 
 /// This uses the same names as serde + "Title Case" variant.

--- a/kinded_macros/src/models.rs
+++ b/kinded_macros/src/models.rs
@@ -1,6 +1,6 @@
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
-use syn::{Generics, Path, Visibility};
+use syn::{Generics, Path, Visibility, Meta as SynMeta};
 
 #[derive(Debug)]
 pub struct Meta {
@@ -55,6 +55,12 @@ impl Meta {
 
         quote!(#type_name #generics)
     }
+
+    pub fn derive_attrs(&self) -> Vec<SynMeta> {
+        self.kinded_attrs.attr
+            .clone()
+            .unwrap_or(Vec::new())
+    }
 }
 
 #[derive(Debug)]
@@ -87,6 +93,8 @@ pub struct KindedAttributes {
 
     /// Attributes to customize implementation for Display trait
     pub display: Option<DisplayCase>,
+
+    pub attr: Option<Vec<SynMeta>>,
 }
 
 /// This uses the same names as serde + "Title Case" variant.

--- a/kinded_macros/src/parse.rs
+++ b/kinded_macros/src/parse.rs
@@ -5,7 +5,7 @@ use syn::{
     bracketed, parenthesized,
     parse::{Parse, ParseStream},
     spanned::Spanned,
-    Attribute, Data, DeriveInput, LitStr, Path, Token,
+    Attribute, Data, DeriveInput, LitStr, Path, Token, Meta as SynMeta,
 };
 
 pub fn parse_derive_input(input: DeriveInput) -> Result<Meta, syn::Error> {
@@ -148,6 +148,12 @@ impl Parse for KindedAttributes {
                     let msg = format!("Duplicated attribute: {attr_name}");
                     return Err(syn::Error::new(attr_name.span(), msg));
                 }
+            } else if attr_name == "attrs" {
+                let derive_input;
+                parenthesized!(derive_input in input);
+
+                let parsed_attr = derive_input.parse_terminated(SynMeta::parse, Token![,])?;
+                kinded_attrs.attr = Some(parsed_attr.into_iter().collect());
             } else {
                 let msg = format!("Unknown attribute: {attr_name}");
                 return Err(syn::Error::new(attr_name.span(), msg));

--- a/kinded_macros/src/parse.rs
+++ b/kinded_macros/src/parse.rs
@@ -153,7 +153,7 @@ impl Parse for KindedAttributes {
                 parenthesized!(derive_input in input);
 
                 let parsed_attr = derive_input.parse_terminated(SynMeta::parse, Token![,])?;
-                kinded_attrs.attr = Some(parsed_attr.into_iter().collect());
+                kinded_attrs.meta_attrs = Some(parsed_attr.into_iter().collect());
             } else {
                 let msg = format!("Unknown attribute: {attr_name}");
                 return Err(syn::Error::new(attr_name.span(), msg));

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -7,3 +7,5 @@ edition = "2021"
 
 [dependencies]
 kinded = {  path = "../kinded" }
+serde = { version = "1.0.197", features = ["derive"] }
+serde_json = "1.0.114"

--- a/test_suite/src/lib.rs
+++ b/test_suite/src/lib.rs
@@ -2,8 +2,10 @@
 #![allow(dead_code)]
 
 use kinded::Kinded;
+use serde::{Deserialize, Serialize};
 
-#[derive(Kinded)]
+#[derive(Kinded, Serialize, Deserialize)]
+#[kinded(derive(Serialize), attrs(serde(rename_all = "camelCase")))]
 enum Role {
     Guest,
     User(i32),
@@ -281,6 +283,20 @@ mod kind_enum {
                     RoleKind::all(),
                     [RoleKind::Guest, RoleKind::User, RoleKind::Admin]
                 )
+            }
+        }
+
+        mod attributes {
+            use serde_json::json;
+            use crate::RoleKind;
+
+            #[test]
+            fn should_respect_opaque_attr_values() {
+                let value = serde_json::to_value(&RoleKind::Guest)
+                    .unwrap();
+
+                dbg!(&value);
+                assert_eq!(value, json!("guest"));
             }
         }
     }


### PR DESCRIPTION
Hi,

I recently ran into the issue of needing the ability to add inner attributes to the generated kind enum for when using with Serde and opted to fork the lib and implement it. Not sure if this is something you want to add, but creating a PR for you to review.

It adds `attrs` attribute to the kinded attribute used in the derive macro:

```rust
use kinded::Kinded;
use serde::Serialize;
use serde_json::json;

#[derive(Kinded, Serialize)]
#[kinded(display = "snake_case", attrs(
    serde(rename_all = "snake_case"))
)]
enum Drink {
    VeryHotBlackTea,
    Milk { fat: f64 },
}

fn main() {
    let json_value = serde_json::to_value(&DrinkKind::VeryHotBlackTea);
    assert_eq!(json_value, json!("very_hot_black_tea"));
}
```

Anyway, let me know what you think and if this is something you would like to merge. Probably needs some more tests if you do want to merge this, but just let me know.
