### PR TITLE
Feat: added ability to opt-out of behaviors (notably, `default_derives`)

### DIFF
--- a/kinded_macros/src/gen/kind_enum.rs
+++ b/kinded_macros/src/gen/kind_enum.rs
@@ -93,6 +93,15 @@ fn apply_maybe_case(original: String, maybe_display_case: Option<DisplayCase>) -
 }
 
 fn gen_impl_from_str_trait(meta: &Meta) -> TokenStream {
+    if meta
+        .kinded_attrs
+        .opt_outs
+        .as_ref()
+        .is_some_and(|opt_outs| opt_outs.from_str_impl)
+    {
+        return proc_macro2::TokenStream::new();
+    }
+
     let kind_name = meta.kind_name();
 
     let original_match_branches = meta.variants.iter().map(|variant| {

--- a/kinded_macros/src/gen/kind_enum.rs
+++ b/kinded_macros/src/gen/kind_enum.rs
@@ -61,6 +61,15 @@ fn gen_impl_from_traits(meta: &Meta) -> TokenStream {
 }
 
 fn gen_impl_display_trait(meta: &Meta) -> TokenStream {
+    if meta
+        .kinded_attrs
+        .opt_outs
+        .as_ref()
+        .is_some_and(|opt_outs| opt_outs.display_impl)
+    {
+        return proc_macro2::TokenStream::new();
+    }
+
     let kind_name = meta.kind_name();
     let maybe_case = meta.kinded_attrs.display;
 

--- a/kinded_macros/src/models.rs
+++ b/kinded_macros/src/models.rs
@@ -32,10 +32,19 @@ impl Meta {
     pub fn derive_traits(&self) -> Vec<Path> {
         const DEFAULT_DERIVE_TRAITS: &[&str] = &["Debug", "Clone", "Copy", "PartialEq", "Eq"];
 
-        let mut traits: Vec<Path> = DEFAULT_DERIVE_TRAITS
-            .iter()
-            .map(|trait_name| Path::from(format_ident!("{trait_name}")))
-            .collect();
+        let mut traits: Vec<Path> = if self
+            .kinded_attrs
+            .opt_outs
+            .as_ref()
+            .is_some_and(|opt_outs| opt_outs.default_derives)
+        {
+            vec![]
+        } else {
+            DEFAULT_DERIVE_TRAITS
+                .iter()
+                .map(|trait_name| Path::from(format_ident!("{trait_name}")))
+                .collect()
+        };
 
         // Add the extra specified traits, if they're different from the default ones
         if let Some(ref extra_traits) = self.kinded_attrs.derive {
@@ -76,6 +85,19 @@ pub enum FieldsType {
     Unit,
 }
 
+#[derive(Debug)]
+pub struct OptOuts {
+    pub default_derives: bool,
+}
+
+impl Default for OptOuts {
+    fn default() -> Self {
+        Self {
+            default_derives: false,
+        }
+    }
+}
+
 /// Attributes specified with #[kinded(..)]
 #[derive(Debug, Default)]
 pub struct KindedAttributes {
@@ -87,6 +109,9 @@ pub struct KindedAttributes {
 
     /// Attributes to customize implementation for Display trait
     pub display: Option<DisplayCase>,
+
+    /// Attributes to opt out of default behaviors`
+    pub opt_outs: Option<OptOuts>,
 }
 
 /// This uses the same names as serde + "Title Case" variant.

--- a/kinded_macros/src/models.rs
+++ b/kinded_macros/src/models.rs
@@ -89,6 +89,7 @@ pub enum FieldsType {
 pub struct OptOuts {
     pub default_derives: bool,
     pub from_str_impl: bool,
+    pub display_impl: bool,
 }
 
 impl Default for OptOuts {
@@ -96,6 +97,7 @@ impl Default for OptOuts {
         Self {
             default_derives: false,
             from_str_impl: false,
+            display_impl: false,
         }
     }
 }

--- a/kinded_macros/src/models.rs
+++ b/kinded_macros/src/models.rs
@@ -88,12 +88,14 @@ pub enum FieldsType {
 #[derive(Debug)]
 pub struct OptOuts {
     pub default_derives: bool,
+    pub from_str_impl: bool,
 }
 
 impl Default for OptOuts {
     fn default() -> Self {
         Self {
             default_derives: false,
+            from_str_impl: false,
         }
     }
 }

--- a/kinded_macros/src/parse.rs
+++ b/kinded_macros/src/parse.rs
@@ -1,4 +1,4 @@
-use crate::models::{DisplayCase, FieldsType, KindedAttributes, Meta, Variant};
+use crate::models::{DisplayCase, FieldsType, KindedAttributes, Meta, OptOuts, Variant};
 use proc_macro2::Ident;
 use quote::ToTokens;
 use syn::{
@@ -147,6 +147,25 @@ impl Parse for KindedAttributes {
                 } else {
                     let msg = format!("Duplicated attribute: {attr_name}");
                     return Err(syn::Error::new(attr_name.span(), msg));
+                }
+            } else if attr_name == "opt_outs" {
+                let _: Token!(=) = input.parse()?;
+                let opt_outs_input;
+                bracketed!(opt_outs_input in input);
+                let mut opt_outs = OptOuts::default();
+                while !opt_outs_input.is_empty() {
+                    let opt_out_name: Ident = opt_outs_input.parse()?;
+                    if opt_out_name == "default_derives" {
+                        opt_outs.default_derives = true;
+                    } else {
+                        let msg = format!("Unknown opt-out attribute: {opt_out_name}");
+                        return Err(syn::Error::new(opt_out_name.span(), msg));
+                    }
+
+                    // Parse `,` unless it's the end of the stream
+                    if !opt_outs_input.is_empty() {
+                        let _comma: Token![,] = opt_outs_input.parse()?;
+                    }
                 }
             } else {
                 let msg = format!("Unknown attribute: {attr_name}");

--- a/kinded_macros/src/parse.rs
+++ b/kinded_macros/src/parse.rs
@@ -159,6 +159,8 @@ impl Parse for KindedAttributes {
                         opt_outs.default_derives = true;
                     } else if opt_out_name == "from_str_impl" {
                         opt_outs.from_str_impl = true;
+                    } else if opt_out_name == "display_impl" {
+                        opt_outs.display_impl = true;
                     } else {
                         let msg = format!("Unknown opt-out attribute: {opt_out_name}");
                         return Err(syn::Error::new(opt_out_name.span(), msg));

--- a/kinded_macros/src/parse.rs
+++ b/kinded_macros/src/parse.rs
@@ -167,6 +167,7 @@ impl Parse for KindedAttributes {
                         let _comma: Token![,] = opt_outs_input.parse()?;
                     }
                 }
+                kinded_attrs.opt_outs = Some(opt_outs);
             } else {
                 let msg = format!("Unknown attribute: {attr_name}");
                 return Err(syn::Error::new(attr_name.span(), msg));

--- a/kinded_macros/src/parse.rs
+++ b/kinded_macros/src/parse.rs
@@ -157,6 +157,8 @@ impl Parse for KindedAttributes {
                     let opt_out_name: Ident = opt_outs_input.parse()?;
                     if opt_out_name == "default_derives" {
                         opt_outs.default_derives = true;
+                    } else if opt_out_name == "from_str_impl" {
+                        opt_outs.from_str_impl = true;
                     } else {
                         let msg = format!("Unknown opt-out attribute: {opt_out_name}");
                         return Err(syn::Error::new(opt_out_name.span(), msg));

--- a/test_suite/src/lib.rs
+++ b/test_suite/src/lib.rs
@@ -13,6 +13,17 @@ enum Role {
     },
 }
 
+// Derivation of these traits can be delegated to another derive macro,
+// e.g. #[derive(EnumSetType)] from `enumset` crate.
+//
+// See <https://github.com/Lymia/enumset/issues/60>
+#[derive(Kinded)]
+#[kinded(opt_outs=[default_derives], derive(Debug, Clone, Copy, PartialEq, Eq))]
+enum Drink {
+    Tea(&'static str),
+    Coffee(&'static str),
+}
+
 mod main_enum {
     use super::*;
 


### PR DESCRIPTION
I wanted to use `kinded` to generate a fieldless enum, as required by `#[derive(EnumSetType)]` from `enumset` crate (see <https://github.com/Lymia/enumset/issues/60>).

However, there was a conflict of derived traits.

This PR adds an option to opt-out of default derives (and other potentially problematic items).